### PR TITLE
Fixed issue with the descriptive record

### DIFF
--- a/Generator/AbaFileGenerator.php
+++ b/Generator/AbaFileGenerator.php
@@ -126,14 +126,8 @@ class AbaFileGenerator
         // Record Type
         $line = self::DESCRIPTIVE_TYPE;
 
-        // BSB
-        $line .= $this->bsb;
-
-        // Account Number
-        $line .= str_pad($this->accountNumber, 9, ' ', STR_PAD_LEFT);
-
-        // Reserved - must be a single blank space
-        $line .= ' ';
+        // Reserved - must be seventeen blank spaces
+        $line .= str_repeat(' ', 17);
 
         // Sequence Number
         $line .= '01';


### PR DESCRIPTION
As per the ABA documentation their must be 17 blank spaces after the Record Type.

Reference - https://www.cemtexaba.com/aba-format/cemtex-aba-file-format-details