### PR TITLE
Option to turn off inclusion of account number in descriptive record

### DIFF
--- a/Generator/AbaFileGenerator.php
+++ b/Generator/AbaFileGenerator.php
@@ -77,7 +77,7 @@ class AbaFileGenerator
      * 
      * Defaults to today.
      * 
-     * @var int|string|DateTime
+     * @var int|string|\DateTime
      */
     private $processingDate;
 
@@ -101,7 +101,7 @@ class AbaFileGenerator
     /**
      * Set the processing date.
      * 
-     * @param int|string|DateTime $date
+     * @param int|string|\DateTime $date
      */
     public function setProcessingDate($date)
     {
@@ -315,8 +315,16 @@ class AbaFileGenerator
             throw new Exception('Detail record transaction indicator is invalid. Must be one of W, X, Y or null.');
         }
 
+        if (! preg_match('/^[\d]{0,10}$/', $transaction->getAmount())) {
+            throw new Exception('Detail record amount is invalid. Must be expressed in cents, as an unsigned integer, no longer than 10 digits.');
+        }
+
+        if (strlen($transaction->getAccountName()) > 32) {
+            throw new Exception('Detail record account name is invalid. Cannot exceed 32 characters.');
+        }
+
         if (! preg_match('/^[A-Za-z0-9\s+]{0,18}$/', $transaction->getReference())) {
-            throw new Exception('Detail record reference is invalid: "'.$transaction->getReference().'". Must be letters only and up to 18 characters long.');
+            throw new Exception('Detail record reference is invalid: "'.$transaction->getReference().'". Must be letters or numbers only and up to 18 characters long.');
         }
 
         if ($transaction->getRemitter() && ! preg_match('/^[A-Za-z\s+]{0,16}$/', $transaction->getRemitter())) {

--- a/Generator/AbaFileGenerator.php
+++ b/Generator/AbaFileGenerator.php
@@ -82,6 +82,11 @@ class AbaFileGenerator
     private $processingDate;
 
     /**
+     * @var bool
+     */
+    private $includeAccountNumberInDescriptiveRecord = true;
+
+    /**
      * Validates that the BSB is 6 digits with a dash in the middle: 123-456
      */
     private $bsbRegex = '/^[\d]{3}-[\d]{3}$/';
@@ -106,6 +111,21 @@ class AbaFileGenerator
     public function setProcessingDate($date)
     {
         $this->processingDate = $date;
+
+        return $this;
+    }
+
+    /**
+     * Set whether to include the remitter's bank account number and BSB in the descriptive record
+     * header. Defaults to true for historic reasons. Some banks will require you to change this to
+     * false.
+     *
+     * @param bool $value
+     * @return $this
+     */
+    public function setIncludeAccountNumberInDescriptiveRecord($value)
+    {
+        $this->includeAccountNumberInDescriptiveRecord = $value;
 
         return $this;
     }
@@ -147,14 +167,19 @@ class AbaFileGenerator
         // Record Type
         $line = self::DESCRIPTIVE_TYPE;
 
-        // BSB
-        $line .= $this->bsb;
+        if ($this->includeAccountNumberInDescriptiveRecord) {
+            // BSB
+            $line .= $this->bsb;
 
-        // Account Number
-        $line .= str_pad($this->accountNumber, 9, ' ', STR_PAD_LEFT);
+            // Account Number
+            $line .= str_pad($this->accountNumber, 9, ' ', STR_PAD_LEFT);
 
-        // Reserved - must be a single blank space
-        $line .= ' ';
+            // Reserved - must be a single blank space
+            $line .= ' ';
+        } else {
+            // Reserved - must be 17 blank spaces
+            $line .= str_repeat(' ', 17);
+        }
 
         // Sequence Number
         $line .= '01';

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -60,6 +60,10 @@ class Transaction implements TransactionInterface
         return $this->amount;
     }
 
+    /**
+     * @param integer $amount The transaction amount in cents.
+     * @return $this
+     */
     public function setAmount($amount)
     {
         $this->amount = $amount;

--- a/Model/TransactionInterface.php
+++ b/Model/TransactionInterface.php
@@ -15,7 +15,7 @@ interface TransactionInterface
     const DEBENTURE_OR_NOTE_INTEREST = '57';
 
     /**
-     * Bank account name for this transaction.
+     * Bank account name for this transaction. Must be 32 characters or less.
      *
      * @return string
      */

--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ file_put_contents('/my/aba/file.aba', $abaString);
 - http://www.anz.com/Documents/AU/corporate/clientfileformats.pdf
 - http://www.cemtexaba.com/aba-format/cemtex-aba-file-format-details.html
 - https://github.com/mjec/aba/blob/master/sample-with-comments.aba
+- https://www.fileactive.anz.com/filechecker


### PR DESCRIPTION
This library always puts the remitter's account details in the descriptive record, but Westpac rejects files that do this. So i've turned it into an option (which defaults to the current behaviour).

Also added some additional validation rules

- Validate amount format
- Validate max length of account name